### PR TITLE
:bug: List<String> values is not formatted in camel case if asset is written in snake case

### DIFF
--- a/lib/src/dart_class_generator.dart
+++ b/lib/src/dart_class_generator.dart
@@ -164,7 +164,11 @@ class DartClassGenerator {
     final valuesList = globals.useReferencesList
         ? getListOfReferences(
             properties: staticProperty + constProperty,
-            assetNames: properties.keys.toList())
+            assetNames: properties.keys
+                .map((name) => Formatter.formatName(name,
+                    prefix: group.prefix ?? '',
+                    useUnderScores: group.useUnderScores))
+                .toList())
         : null;
 
     verbose('Constructing dart class for ${group.className}');


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
In the previous pull request to add the values parameter, I forgot to call assenName formatting when adding their to the List<String> values. Because of this, an error appears when generating such pictures.
In this query I corrected my mistake

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->
My previous PR ( https://github.com/BirjuVachhani/spider/pull/39 ) is merged to main and available on pub.dev now. But it have bug and if someone tries use this with snake_case named assets he get an error

### Benefits
### Possible Drawbacks

<!-- What benefits will be realized by the code change? -->
I fix my previous mistake


### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Now I global activated my local brunch and generated dart classes with values property. The problem is gone 

### Applicable Issues

<!-- Enter any applicable Issues here -->
