### PR TITLE
Sort generated file maps by file basenames

### DIFF
--- a/lib/src/dart_class_generator.dart
+++ b/lib/src/dart_class_generator.dart
@@ -85,7 +85,8 @@ class DartClassGenerator {
       verbose(
           'Asset - ${path.basename(file.path)} is ${valid ? 'selected' : 'not selected'}');
       return valid;
-    }).toList();
+    }).toList()
+      ..sort((a, b) => path.basename(a.path).compareTo(path.basename(b.path)));
 
     if (files.isEmpty) {
       info('Directory $dir does not contain any assets!');


### PR DESCRIPTION
### Description of the Change

This change adds basic sorting to the contents of generated file maps (which appear in assets libraries and tests). This is nice to have to ensure each time Spider builds, it creates lists of files in the same order every time.

I need this because in my project we would like to run `spider build` in CI to make sure the developer has regenerated all assets. We use `git diff` to make sure the assets are synced correctly, and without sorting we get a lot of false errors.

### Alternate Designs

This is the simplest change I could think of.

### Why Should This Be In Core?

It's a small change which adds consistency and predictability for users of the package.

### Benefits

Consistency, predictability, ability to use reliably within CI pipelines.

### Possible Drawbacks

No long-term drawbacks that I can think of. Users moving to a version including this change might see a bit more noise in `git diff` the next time they run the `spider build` command.

### Verification Process

- Ran `spider build` following the change
- Verified all assets were still generated
- Verified the assets were listed alphabetically as expected

### Applicable Issues

N/A - happy to create one if needed.



Thanks for the useful project!