### PR TITLE
Feature/ignore-rules

### DIFF
--- a/lib/src/asset_group.dart
+++ b/lib/src/asset_group.dart
@@ -74,7 +74,7 @@ class AssetGroup {
       if (json['sub_groups'] != null) {
         json['sub_groups'].forEach(
             (subgroup) => subgroups!.add(AssetSubgroup.fromJson(subgroup)));
-      } else if (json['subgroup'] != null) {
+      } else if (json['sub_group'] != null) {
         subgroups!.add(AssetSubgroup.fromJson(json['sub_group']));
       }
     }

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -32,6 +32,7 @@ class Constants {
       "[,.\\/;'\\[\\]\\-=<>?:\\\"\\{}_+!@#\$%^&*()\\\\|\\s]+";
   static final Pattern specialSymbolRegex = RegExp(SPECIAL_SYMBOLS);
 
+  static const String KEY_INGORED_RULES = '[IGNORED_RULES]';
   static const String KEY_PROJECT_NAME = '[PROJECT_NAME]';
   static const String KEY_PACKAGE = '[PACKAGE]';
   static const String TEST_IMPORT = '[TEST_IMPORT]';

--- a/lib/src/dart_class_generator.dart
+++ b/lib/src/dart_class_generator.dart
@@ -243,6 +243,7 @@ class DartClassGenerator {
 
     verbose('Constructing dart class for ${group.className}');
     final content = getDartClass(
+      ignoredRules: globals.ignoredRules,
       className: group.className,
       references: references,
       noComments: globals.noComments,

--- a/lib/src/data/export_template.dart
+++ b/lib/src/data/export_template.dart
@@ -17,6 +17,9 @@
 /// A template to add library statement in dart source code.
 String get libraryTemplate => 'library [LIBRARY_NAME];\n\n';
 
+/// A template to add ignore rules.
+String get ignoreRulesTemplate => '// ignore_for_file: [IGNORED_RULES]\n\n';
+
 /// A template to generate export statements in dart source code.
 String get exportFileTemplate => "export '[FILE_NAME]';";
 

--- a/lib/src/data/export_template.dart
+++ b/lib/src/data/export_template.dart
@@ -17,7 +17,7 @@
 /// A template to add library statement in dart source code.
 String get libraryTemplate => 'library [LIBRARY_NAME];\n\n';
 
-/// A template to add ignore rules.
+/// A template to add ignored rules.
 String get ignoreRulesTemplate => '// ignore_for_file: [IGNORED_RULES]\n\n';
 
 /// A template to generate export statements in dart source code.

--- a/lib/src/data/test_template.dart
+++ b/lib/src/data/test_template.dart
@@ -49,13 +49,13 @@ export: true
 # This allows you to import all the generated references with 1 single import!
 use_part_of: true
 
-# Generates a variable that contains a list of all asset values.
+# Generates a variable that contains a list of all asset values
 use_references_list: false
 
 # Location where all the generated references will be stored
 package: resources
 
-#
+# List of linter rules that will be ignored in generated files (except for tests)
 ignored_rules: [ public_member_api_docs, member-ordering-extended, test_rule ]
 
 groups:

--- a/lib/src/data/test_template.dart
+++ b/lib/src/data/test_template.dart
@@ -55,6 +55,9 @@ use_references_list: false
 # Location where all the generated references will be stored
 package: resources
 
+#
+ignored_rules: [ public_member_api_docs, member-ordering-extended, test_rule ]
+
 groups:
   - class_name: Images
     path: assets/images
@@ -106,6 +109,7 @@ String get testJsonConfigTemplate => '''
   "use_part_of":true,
   "use_references_list": false,
   "package":"resources",
+  "ignored_rules": [ "public_member_api_docs", "member-ordering-extended", "test_rule" ],
   "groups": [
     {
       "class_name": "Images",

--- a/lib/src/spider_config.dart
+++ b/lib/src/spider_config.dart
@@ -45,11 +45,13 @@ class GlobalConfigs {
   final bool export;
   String? package;
   bool? usePartOf;
+  final List<String>? ignoredRules;
   final String exportFileName;
   final bool useReferencesList;
   final bool useFlutterTestImports;
 
   GlobalConfigs({
+    required this.ignoredRules,
     required this.generateTests,
     required this.noComments,
     required this.export,
@@ -62,7 +64,14 @@ class GlobalConfigs {
   });
 
   factory GlobalConfigs.fromJson(Map<String, dynamic> json) {
+    List<String>? ignoredRules;
+    if (json['ignored_rules'] != null) {
+      ignoredRules = [];
+      json['ignored_rules'].forEach((rule) => ignoredRules!.add(rule));
+    }
+
     return GlobalConfigs(
+      ignoredRules: ignoredRules,
       generateTests: json['generate_tests'] == true,
       noComments: json['no_comments'] == true,
       export: json['export'] == true,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -165,8 +165,14 @@ String getDartClass({
   required bool usePartOf,
   String? exportFileName,
   required String? valuesList,
+  required List<String>? ignoredRules,
 }) {
   var content = '';
+  if (ignoredRules != null && ignoredRules.isNotEmpty) {
+    content = ignoreRulesTemplate.replaceAll(
+        Constants.KEY_INGORED_RULES, ignoredRules.join(', '));
+  }
+
   if (!noComments) {
     content += timeStampComment.replaceAll(
         Constants.KEY_TIME, DateTime.now().toString());

--- a/test/spider_test.dart
+++ b/test/spider_test.dart
@@ -128,6 +128,11 @@ void main() {
       final classContent3 = genFile3.readAsStringSync();
       final classContent4 = genFile4.readAsStringSync();
 
+      expect(
+          classContent1,
+          contains(
+            '// ignore_for_file: public_member_api_docs, member-ordering-extended, test_rule',
+          ));
       expect(classContent1, contains('class Images'));
       expect(classContent1, contains('static const String test1'));
       expect(classContent1, contains('static const String test2'));


### PR DESCRIPTION
### Description of the Change
Added `ignored_rules` property in global scope.

### Benefits
Now u are able to set your custom set of rules that must be ignored in generated asset-classes.
Linter no longer warns.

### Possible Drawbacks
Don't exist

### Verification Process
Added and passed tests.
Linter no longer warns.

### Applicable Issues
Closes #55
