### PR TITLE
Fix/Package related asset paths are legit now

### DIFF
--- a/lib/src/cli/utils/constants.dart
+++ b/lib/src/cli/utils/constants.dart
@@ -16,6 +16,7 @@ class Constants {
   static const String DEFAULT_PATH = 'assets';
   static const String DEFAULT_CLASS_NAME = 'Assets';
   static const String DEFAULT_PACKAGE = 'resources';
+  static const PACKAGE_ASSET_PATH_PREFIX = 'packages';
 
   static const String CAPITALIZE_REGEX = r'(_)(\S)';
   static const String SPECIAL_SYMBOLS =

--- a/lib/src/cli/utils/helpers.dart
+++ b/lib/src/cli/utils/helpers.dart
@@ -102,9 +102,13 @@ Result<bool> _assertDir(String dir) {
   if (dir.contains('*')) {
     return Result.error(sprintf(ConsoleMessages.noWildcardInPathError, [dir]));
   }
-  if (!Directory(dir).existsSync()) {
+
+  final uri = Uri.parse(dir);
+  final resolvedDir = uri.pathSegments.first != Constants.PACKAGE_ASSET_PATH_PREFIX ? dir : p.join(Constants.LIB_FOLDER, p.joinAll(uri.pathSegments.sublist(2)));
+  if (!FileSystemEntity.isDirectorySync(resolvedDir)) {
     return Result.error(sprintf(ConsoleMessages.pathNotExistsError, [dir]));
   }
+
   final dirName = p.basename(dir);
   if (RegExp(r'^\d.\dx$').hasMatch(dirName)) {
     return Result.error(sprintf(ConsoleMessages.invalidAssetDirError, [dir]));


### PR DESCRIPTION
### Description of the Change

Fulfills issue given
https://github.com/BirjuVachhani/spider/issues/64
more precisely that kind of paths
https://docs.flutter.dev/development/ui/assets-and-images#bundling-of-package-assets

### Alternate Designs

No alternatives considered.

### Why Should This Be In Core?

As this kind of asset paths are legit in Dart ecosystem.

### Benefits

Ability to use the generator with package assets.

### Possible Drawbacks

No imminent drawbacks are expected.

### Verification Process

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?

I have run the generator for package and direct asset paths both. Output paths are whole being generated as expected. 

- How did you verify that the change has not introduced any regressions?

Just verified it by running generator for direct asset paths might be impacted by following changes. No other checks have been executed.

### Applicable Issues

https://github.com/BirjuVachhani/spider/issues/64