### PR TITLE
Bump dart_style version to 3.0.1

### DIFF
--- a/lib/src/dart_class_generator.dart
+++ b/lib/src/dart_class_generator.dart
@@ -27,7 +27,9 @@ class DartClassGenerator {
   bool _processing = false;
 
   /// Dart code formatter used to format the generated code.
-  static final formatter = DartFormatter();
+  static final formatter = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  );
 
   /// Global configuration values retrieved from the config file.
   final GlobalConfigs globals;

--- a/lib/src/fonts_generator.dart
+++ b/lib/src/fonts_generator.dart
@@ -59,7 +59,9 @@ class FontsGenerator {
     writeToFile(
       name: Formatter.formatFileName(globals.fontConfigs.fileName),
       path: globals.package,
-      content: DartFormatter().format(content),
+      content: DartFormatter(
+        languageVersion: DartFormatter.latestLanguageVersion,
+      ).format(content),
     );
     logger?.success('Generated fonts references successfully.');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/BirjuVachhani/spider/issues
 documentation: https://birjuvachhani.github.io/spider/
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 
 platforms:
   linux:
@@ -19,7 +19,7 @@ dependencies:
   path: ^1.9.0
   yaml: ^3.1.2
   args: ^2.5.0
-  dart_style: ^2.3.6
+  dart_style: ^3.0.1
   logging: ^1.2.0
   watcher: ^1.1.0
   http: ^1.2.2


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The change upgrades `dart_style` package to version `^3.0.1` to support for dart's new tall style formatter.

### Alternate Designs

None

### Why Should This Be In Core?

To support new tall formatter

### Benefits

This makes the `spider` package usable with latest `freezed` and `injectable` generator since those package also use `dart_style: ^3.0.1`

### Possible Drawbacks

If the users want old formatter with short syntax then it won't be available.

### Verification Process

What process did you follow to verify that your change has the desired effects?

- I just ran tests and all are passing

### Applicable Issues

None
