### PR TITLE
`[ci skip]` Corrected the update command

### DIFF
--- a/lib/src/cli/utils/constants.dart
+++ b/lib/src/cli/utils/constants.dart
@@ -58,7 +58,7 @@ class Constants {
   |                                                                 |
   |   Run following command to update to the latest version:        |
   |                                                                 |
-  |   pub global activate spider                                    |
+  |   dart pub global activate spider                               |
   |                                                                 |
   ===================================================================
 


### PR DESCRIPTION
### Description of the Change

I just added `dart` keyword to the update message that is shown to users if they have an older version of spider.

If I remember correctly once upon a time we could directly use `pub _____` command but at some dart/flutter team changed that now we need to run it as `dart pub _____` or `flutter pub _____`.

Even in your own ["Readme.md"](https://github.com/MorosophDude/spider/blob/main/README.md#install-using-pub) file, it says `dart pub global activate spider`. That was probably changed at some point, maybe you just missed it in this location.

### Why Should This Be In Core?

To reduce confusion and save time of new users.

### Benefits

Benefits, hmm... In best case, nobody will care about this change. In worst case, some inexperience user would create an Github issue. Actually, it would be funny if some vibe coder gets all pumped up and starts complaining instead of searching for fairly simple and easy to find fix.

### Possible Drawbacks

None.

### Verification Process

What process did you follow to verify that your change has the desired effects?
1. When I ran `pub global activate spider` in my terminal it said `zsh: command not found: pub`
2. When I ran `dart pub global activate spider` it immediately worked like it was supposed to.

### Applicable Issues

None.

#### P.S. Sorry only saw the `Contributing.md` at the end. So I don't know if `[ci skip]` will work.